### PR TITLE
Add functionality to store secrets for SimpleSAMLPHP app integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ To make dealing with the vault easier, you can run `secrets:keychain:init` which
 
 The imagined workflow for this tool is 
 
+## Integration with SimpleSAMLPHP
+
+If you have a need to secretly store config for a SimpleSAMLPHP app integration, see [simplesamlphp_readme.md](simplesamlphp_readme.md).
+
 # License
 
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation.

--- a/ansible/deploy-simplesamlphp-secrets.yml
+++ b/ansible/deploy-simplesamlphp-secrets.yml
@@ -1,0 +1,37 @@
+- name: Deploy secrets
+  hosts: all
+  gather_facts: no
+
+  tasks:
+
+  - name: Get the secrets!
+    include_vars: "{{secret_vault_location}}"
+
+  - name: Test the templates are valid
+    block:
+      - name: test templating secrets file
+        local_action: template src="{{secret_template_location}}" dest="simplesamlphpsecrettemp.php"
+        check_mode: no
+        diff: no
+      - name: lint php files
+        local_action: command php -l simplesamlphpsecrettemp.php | grep "No Syntax"
+        check_mode: no
+        diff: no
+    always:
+      - name: remove temp php files
+        local_action: file state=absent path=simplesamlphpsecrettemp.php
+        check_mode: no
+        no_log: True
+
+  - name: Create local secrets directory
+    file:
+      path: "{{secret_location_dir}}"
+      state: directory
+    when:
+      - secret_location_dir is defined
+
+  - name: Template the secrets file
+
+    template:
+      src: "{{secret_template_location}}"
+      dest: "{{secret_location}}"

--- a/ansible/simplesamlphp.secrets.php.j2
+++ b/ansible/simplesamlphp.secrets.php.j2
@@ -1,0 +1,5 @@
+<?php
+
+// Example simplesamlphp config
+$config['secretsalt'] = '{{simplesamlphp_secrets['secretsalt']}}';
+$config['auth.adminpassword'] = '{{simplesamlphp_secrets['auth.adminpassword'][drush_alias]}}';

--- a/ansible/simplesamlphp_secrets_vault.yml
+++ b/ansible/simplesamlphp_secrets_vault.yml
@@ -1,0 +1,11 @@
+{
+  "simplesamlphp_secrets": {
+    "secretsalt": "y0h9d13pki9qdhfm3l5nws4jjn55j6hj",
+    "auth.adminpassword": {
+      "@local": "localsecret",
+      "@dev": "devsecret",
+      "@test": "testsecret",
+      "@prod": "prodsecret"
+    }
+  }
+}

--- a/simplesamlphp_readme.md
+++ b/simplesamlphp_readme.md
@@ -1,0 +1,92 @@
+Acquia BLT Secret management for SimpleSAMLPHP
+====
+This BLT plugin also includes additional commands to store secrets to be used with SimpleSAMLPHP integration.
+
+## Creating a new vault
+
+Initialize the new vault by calling `secrets:simplesamlphp:vault:init` which will prompt you for a new password to encrypt your vault.
+It will create a minimal vault file for adding your secrets.
+
+## Editing your vault
+
+Call the command `secrets:simplesamlphp:edit` which will prompt for your password to decrypt the vault file. 
+Your default editor will open with a temp file where you can make your changes. Once done, save and close the file for it to be re-enccrypted. 
+You should now commit the vault file to your repository
+
+> Note: You can change the default editor by setting the environment variable DEFAULT_EDITOR
+> 
+> e.g. `export DEFAULT_EDITOR=subl -w`
+
+
+## Diff command
+
+Call the command `secrets:simplesamlphp:diff` with a drush alias and the plugin will first create your simplesamlphp.secrets.php file from your encrypted information, then run a php lint to ensure it is valid PHP. It will then show you any differences between the generated settings file and the file on that environment.  
+
+## Deploy command
+
+Call the command `secrets:simplesamlphp:deploy` with a drush alias and the plugin will first create your simplesamlphp.secrets.php file from your encrypted information, then run a php lint to ensure it is valid PHP. It will then overwrite the settings file on that environment with your new values.
+
+## Adding new settings
+
+The plugin requires to elements. 
+* the vault-file with your credentials
+* A simplesamlphp.secrets.php template to show how your credentials are used 
+
+The vault file is in JSON format and allows you to have a different credential per environment.
+
+```json
+{
+  "simplesamlphp_secrets": {
+    "secretsalt": "y0h9d13pki9qdhfm3l5nws4jjn55j6hj",
+    "auth.adminpassword": {
+      "@local": "localsecret",
+      "@dev": "devsecret",
+      "@test": "testsecret",
+      "@prod": "prodsecret"
+    }
+  }
+}
+```
+
+You should add your own credentials in the `simplesaml_secrets` array, and update the environment names to match your drush aliases
+
+To edit this file, run `secrets:simplesamlphp:edit`
+
+The secrets.settings.php template is located in `/secrets/simplesamlphp.secrets.php.j2` and uses the jinja templating language.
+
+```php
+<?php
+
+// Example simplesamlphp config
+$config['secretsalt'] = '{{simplesamlphp_secrets['secretsalt']}}';
+$config['auth.adminpassword'] = '{{simplesamlphp_secrets['auth.adminpassword'][drush_alias]}}';
+```
+
+The jinja variable `{{simplesamlphp_secrets['auth.adminpassword'][drush_alias]}}` will get data from your vault.
+
+Add new settings as needed.
+
+## Passwords in keychain
+
+To make dealing with the vault easier, you can run `secrets:keychain:init` which will prompt you for your vault password, add it to your keychain and then use that in future instead of prompting for your password each time. Note that it will store the password in the index in the keychain that the Drupal secrets vault uses, so the two vaults will need to be created with the same password if the keychain and both vaults are used.
+
+## Appending to `acquia_config.php`
+
+In order for the SimpleSAMLPHP app to pick up the secrets file created by the vault, you can run `secrets:simplesamlphp:acquia_config:include`. This will append:
+
+```php
+if (file_exists('{RELATIVE PATH TO LOCAL SECRETS INCLUDE FILE}')) {
+  // If the local simplesamlphp secrets file exists, include it.
+  include '{RELATIVE PATH TO LOCAL SECRETS INCLUDE FILE}';
+}
+elseif (file_exists('/mnt/files/' . getenv('AH_SITE_GROUP') . '.' . getenv('AH_SITE_ENVIRONMENT') . '/simplesamlphp.secrets.php')) {
+  // Otherwise include the cloud simplesamlphp secrets file if it exists.
+  include '/mnt/files/' . getenv('AH_SITE_GROUP') . '.' . getenv('AH_SITE_ENVIRONMENT') . '/simplesamlphp.secrets.php';
+}
+```
+
+The local secrets include file is located at `/scripts/simplesamlphp/secrets.php.local` in your BLT project, if you have either run a diff or deploy to your local alias.
+
+Note that the include is only appended to the `/simplesamlphp/acquia_config.php` in your BLT project. You may need to manually edit the file to place the include in the appropriate place or delete any lines from `acquia_config.php` that the include is meant to replace.
+
+Once ready, run `source:build:simplesamlphp-config` to make sure the SimpleSAMLPHP config is correctly updated and copied to the app directory in `/vendor`.

--- a/src/Blt/Plugin/Commands/SecretsCommands.php
+++ b/src/Blt/Plugin/Commands/SecretsCommands.php
@@ -248,6 +248,7 @@ class SecretsCommands extends BltTasks {
         secret_vault_location=" . $secret_vault_location . " \
         secret_template_location=" . $secret_template_location . " \
         secret_location=" . $secret_location . " \
+        secret_location_dir=" . dirname($secret_location) . " \
         localsettings_location=" . $local_extra_vars . " \
         ansible_connection=local' "
         . $this->getVaultPasswordCommand();

--- a/src/Blt/Plugin/Commands/SecretsCommands.php
+++ b/src/Blt/Plugin/Commands/SecretsCommands.php
@@ -80,7 +80,14 @@ class SecretsCommands extends BltTasks {
         throw new BltException("Could not initialize secrets configuration.");
       }
 
-      $this->taskExec("ansible-vault encrypt " . $this->getConfigValue('repo.root') . "$this->pluginRoot/ansible/secrets_vault.yml --ask-vault-pass --output secrets/secrets_vault")->run();
+      if (file_exists($this->getConfigValue('repo.root') . '/secrets/.usekeychain') &&
+          $this->confirm("Use vault password in keychain?")) {
+        $password_command = $this->getVaultPasswordCommand();
+      }
+      else {
+        $password_command = ' --ask-vault-pass';
+      }
+      $this->taskExec("ansible-vault encrypt " . $this->getConfigValue('repo.root') . "$this->pluginRoot/ansible/$this->vaultFile.yml $password_command --output secrets/$this->vaultFile")->run();
 
       $this->say("<info>A New ansible-vault and template were copied to your repository.</info>");
       $this->say("<info>Run '$this->editCommand' to edit your vault.</info>");

--- a/src/Blt/Plugin/Commands/SimplesamlphpSecretsCommands.php
+++ b/src/Blt/Plugin/Commands/SimplesamlphpSecretsCommands.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Acquia\SecretsManagement\Blt\Plugin\Commands;
+
+use Acquia\Blt\Robo\Exceptions\BltException;
+use Robo\Contract\VerbosityThresholdInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Defines commands in the "secrets:simplesamlphp" namespace.
+ */
+class SimplesamlphpSecretsCommands extends SecretsCommands {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $secretsPhpFile = 'simplesamlphp.secrets.php';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $vaultFile = 'simplesamlphp_secrets_vault';
+
+  /**
+   * @var string
+   */
+  protected $editCommand = 'blt secrets:simplesamlphp:edit';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $playbookFile = 'deploy-simplesamlphp-secrets.yml';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $playbookConfigKey = 'secrets.simplesamlphp.playbook';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $localSecretsPath = '/scripts/simplesamlphp/secrets.php.local';
+
+  /**
+   * Initializes simplesamlphp secrets configuration for this project.
+   *
+   * @command secrets:simplesamlphp:vault:init
+   */
+  public function secretsInit() {
+    parent::secretsInit();
+  }
+
+  /**
+   * Edit the simplesamlphp vault file.
+   *
+   * @command secrets:simplesamlphp:edit
+   * @aliases sesed
+   */
+  public function secretsEdit() {
+    parent::secretsEdit();
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @command secrets:simplesamlphp:diff
+   * @aliases sesdf
+   */
+  public function secretsDiff($drushAlias) {
+    parent::secretsDiff($drushAlias);
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @command secrets:simplesamlphp:deploy
+   * @aliases sesdp
+   */
+  public function secretsDeploy($drushAlias) {
+    parent::secretsDeploy($drushAlias);
+  }
+
+  /**
+   * Appends include for the secrets to the acquia_config.php file.
+   *
+   * @command secrets:simplesamlphp:acquia_config:include
+   * @aliases sesaci
+   */
+  public function appendToAcquiaConfig() {
+    $repo_root = $this->getConfigValue('repo.root');
+    $config_file = $repo_root . '/simplesamlphp/config/acquia_config.php';
+    if (!file_exists($config_file)) {
+      throw new BltException("<error>File $config_file not found. Make sure that you have run 'blt recipes:simplesamlphp:init'.</error>");
+    }
+    // Local include path is relative to
+    // vendor/simplesamlphp/simplesamlphp/config.
+    $fs = new Filesystem();
+    $local_include = rtrim($fs->makePathRelative($repo_root . $this->localSecretsPath, $repo_root . '/vendor/simplesamlphp/simplesamlphp/config'), '/');
+    $include_text = <<<EOT
+if (file_exists('$local_include')) {
+  // If the local simplesamlphp secrets file exists, include it.
+  include '$local_include';
+}
+elseif (file_exists('/mnt/files/' . getenv('AH_SITE_GROUP') . '.' . getenv('AH_SITE_ENVIRONMENT') . '/simplesamlphp.secrets.php')) {
+  // Otherwise include the cloud simplesamlphp secrets file if it exists.
+  include '/mnt/files/' . getenv('AH_SITE_GROUP') . '.' . getenv('AH_SITE_ENVIRONMENT') . '/simplesamlphp.secrets.php';
+}
+EOT;
+
+    $result = $this->taskWriteToFile($config_file)
+      ->text($include_text)
+      ->append()
+      ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+      ->run();
+    if (!$result->wasSuccessful()) {
+      throw new BltException("Unable modify $config_file.");
+    }
+    else {
+      $this->output->writeln('Secrets file include appended to acquia_config.php. You may need to manually edit the file to work correctly.');
+    }
+  }
+
+}


### PR DESCRIPTION
This PR extends the BLT secrets management plugin to add functionality to store secrets for the SimpleSAMLPHP app, if it is integrated with Drupal to use for SSO.

Changes include:

- Making some strings into class properties in the original command class so that they can be overridden in a subclass for SAML commands
- Creating a separate ansible playbook for SimpleSAML integration
- Separate ansible vault
- Replicating all the commands for SimpleSAML secrets
- Creating a command to add PHP include statements to the `acquia_config.php` where the secrets will be container.