### PR TITLE
Add multistack support to plugin

### DIFF
--- a/ansible/deploy-secrets.yml
+++ b/ansible/deploy-secrets.yml
@@ -49,17 +49,30 @@
         - localsettings_location is defined
         - not ansible_check_mode
 
+    - name: Ensure directories exist
+      file:
+        state: directory
+        dest: "{{ (env_path + item) | dirname }}"
+      loop: "{{ file_dests }}"
+
+    - name: Ensure update directories exist
+      file:
+        state: directory
+        dest: "{{ (update_env_path + item) | dirname }}"
+      loop: "{{ file_dests }}"
+      when:
+        - update_env_path is defined
+
     - name: Copy encrypted files
       copy:
         src: "../../../../{{ item.0 }}"
         dest: "{{ env_path }}{{ item.1 }}"
       loop: "{{ file_srcs|zip(file_dests)|list }}"
 
-    - name: Symlink encrypted file to update env
+    - name: Copy encrypted file to update env
       file:
-        src: "{{ env_path }}{{ item.1 }}"
+        src: "../../../../{{ item.0 }}"
         dest: "{{ update_env_path }}{{ item.1 }}"
-        state: link
       loop: "{{ file_srcs|zip(file_dests)|list }}"
       when:
         - update_env_path is defined

--- a/ansible/deploy-secrets.yml
+++ b/ansible/deploy-secrets.yml
@@ -4,39 +4,62 @@
 
   tasks:
 
-  - name: Get the secrets!
-    include_vars: "{{secret_vault_location}}"
+    - name: Get the secrets!
+      include_vars: "{{secret_vault_location}}"
 
-  - name: Test the templates are valid
-    block:
-      - name: test templating secrets file
-        local_action: template src="{{secret_template_location}}" dest="secrettemp.php"
-        check_mode: no
-        diff: no
-      - name: lint php files
-        local_action: command php -l secrettemp.php | grep "No Syntax"
-        check_mode: no
-        diff: no
-    always:
-      - name: remove temp php files
-        local_action: file state=absent path=secrettemp.php
-        check_mode: no
-        no_log: True
+    - name: Test the templates are valid
+      block:
+        - name: test templating secrets file
+          local_action: template src="{{secret_template_location}}" dest="secrettemp.php"
+          check_mode: no
+          diff: no
+        - name: lint php files
+          local_action: command php -l secrettemp.php | grep "No Syntax"
+          check_mode: no
+          diff: no
+      always:
+        - name: remove temp php files
+          local_action: file state=absent path=secrettemp.php
+          check_mode: no
+          no_log: True
 
-  - name: Template the secrets file
-    template:
-      src: "{{secret_template_location}}"
-      dest: "{{secret_location}}"
+    - name: Template the secrets file
+      template:
+        src: "{{secret_template_location}}"
+        dest: "{{env_path}}{{secret_location}}"
 
-  - name: Include secrets on local
-    blockinfile:
-      path: "{{localsettings_location}}"
-      marker: "// {mark} added by ansible (secrets config)"
-      mode: 0644
-      block: |
-        if (file_exists($dir . '/docroot/sites/default/settings/secrets.settings.local')) {
-          require $dir . '/docroot/sites/default/settings/secrets.settings.local';
-        }
-    when:
-      - localsettings_location is defined
-      - not ansible_check_mode
+    - name: Symlink secrets file to update env
+      file:
+        src: "{{ env_path }}{{ secret_location }}"
+        dest: "{{ update_env_path }}{{secret_location}}"
+        state: link
+      when:
+        - update_env_path is defined
+
+    - name: Include secrets on local
+      blockinfile:
+        path: "{{localsettings_location}}"
+        marker: "// {mark} added by ansible (secrets config)"
+        mode: 0644
+        block: |
+          if (file_exists($dir . '/docroot/sites/default/settings/secrets.settings.local')) {
+            require $dir . '/docroot/sites/default/settings/secrets.settings.local';
+          }
+      when:
+        - localsettings_location is defined
+        - not ansible_check_mode
+
+    - name: Copy encrypted files
+      copy:
+        src: "../../../../{{ item.0 }}"
+        dest: "{{ env_path }}{{ item.1 }}"
+      loop: "{{ file_srcs|zip(file_dests)|list }}"
+
+    - name: Symlink encrypted file to update env
+      file:
+        src: "{{ env_path }}{{ item.1 }}"
+        dest: "{{ update_env_path }}{{ item.1 }}"
+        state: link
+      loop: "{{ file_srcs|zip(file_dests)|list }}"
+      when:
+        - update_env_path is defined

--- a/ansible/deploy-secrets.yml
+++ b/ansible/deploy-secrets.yml
@@ -71,8 +71,9 @@
 
     - name: Copy encrypted file to update env
       file:
-        src: "../../../../{{ item.0 }}"
+        src: "{{ env_path }}{{ item.1 }}"
         dest: "{{ update_env_path }}{{ item.1 }}"
+        state: link
       loop: "{{ file_srcs|zip(file_dests)|list }}"
       when:
         - update_env_path is defined

--- a/src/Blt/Plugin/Commands/SecretsCommands.php
+++ b/src/Blt/Plugin/Commands/SecretsCommands.php
@@ -266,7 +266,11 @@ class SecretsCommands extends BltTasks {
         // Set the update environment identifier if this is an ACSF project.
         // Mimics the environment detector logic but without requiring Drupal to be bootstrapped.
         if (file_exists($this->getConfigValue('repo.root') . "/docroot/sites/g")) {
-            $facts['ac_update_env'] = $facts['ac_env'] . "up";
+            if ($facts['stack_env'] == 'live') {
+                $facts['ac_update_env'] = $facts['stack'] . "update";
+              } else {
+                $facts['ac_update_env'] = $facts['ac_env'] . "up";
+              }
         }
 
 

--- a/src/Blt/Plugin/Commands/SecretsCommands.php
+++ b/src/Blt/Plugin/Commands/SecretsCommands.php
@@ -11,236 +11,264 @@ use Robo\Contract\VerbosityThresholdInterface;
  */
 class SecretsCommands extends BltTasks {
 
-  /**
-   * The directory containing this file.
-   *
-   * @var string
-   */
-  private $pluginRoot = '/vendor/nedsbeds/blt-secrets-management';
+    /**
+     * The directory containing this file.
+     *
+     * @var string
+     */
+    private $pluginRoot = '/vendor/nedsbeds/blt-secrets-management';
 
-  /**
-   * The environments from drush aliases
-   *
-   * @var array
-   */
-  private $environments = null;
+    /**
+     * The environments from drush aliases
+     *
+     * @var array
+     */
+    private $environments = null;
 
-  /**
-   * Initializes default secrets configuration for this project.
-   *
-   * @command secrets:vault:init
-   * @throws \Acquia\Blt\Robo\Exceptions\BltException
-   */
-  public function secretsInit() {
+    /**
+     * Initializes default secrets configuration for this project.
+     *
+     * @command secrets:vault:init
+     * @throws \Acquia\Blt\Robo\Exceptions\BltException
+     */
+    public function secretsInit() {
 
-    if ($this->confirm("<error>Are you sure you want to initialise? This will overwrite any existing encrypted vaults</error>", FALSE)) {
+        if ($this->confirm("<error>Are you sure you want to initialise? This will overwrite any existing encrypted vaults</error>", FALSE)) {
 
-      $result = $this->taskFilesystemStack()
-        ->copy($this->getConfigValue('repo.root') . $this->pluginRoot . '/ansible/secrets.settings.php.j2', $this->getConfigValue('repo.root') . '/secrets/secrets.settings.php.j2', TRUE)
-        ->copy($this->getConfigValue('repo.root') . $this->pluginRoot . '/ansible/.gitignore', $this->getConfigValue('repo.root') . '/secrets/.gitignore', TRUE)
-        ->stopOnFail()
-        ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
-        ->run();
+            $result = $this->taskFilesystemStack()
+                ->copy($this->getConfigValue('repo.root') . $this->pluginRoot . '/ansible/secrets.settings.php.j2', $this->getConfigValue('repo.root') . '/secrets/secrets.settings.php.j2', TRUE)
+                ->copy($this->getConfigValue('repo.root') . $this->pluginRoot . '/ansible/.gitignore', $this->getConfigValue('repo.root') . '/secrets/.gitignore', TRUE)
+                ->stopOnFail()
+                ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+                ->run();
 
-      if (!$result->wasSuccessful()) {
-        throw new BltException("Could not initialize secrets configuration.");
-      }
+            if (!$result->wasSuccessful()) {
+                throw new BltException("Could not initialize secrets configuration.");
+            }
 
-      $this->taskExec("ansible-vault encrypt " . $this->getConfigValue('repo.root') . "$this->pluginRoot/ansible/secrets_vault.yml --ask-vault-pass --output secrets/secrets_vault")->run();
+            $this->taskExec("ansible-vault encrypt " . $this->getConfigValue('repo.root') . "$this->pluginRoot/ansible/secrets_vault.yml --ask-vault-pass --output secrets/secrets_vault")->run();
 
-      $this->say("<info>A New ansible-vault and template were copied to your repository.</info>");
-      $this->say("<info>Run 'blt secrets:edit' to edit your vault.</info>");
+            $this->say("<info>A New ansible-vault and template were copied to your repository.</info>");
+            $this->say("<info>Run 'blt secrets:edit' to edit your vault.</info>");
+        }
     }
-  }
 
-  /**
-   * Adds your vault password to the keychain.
-   *
-   * @command secrets:keychain:init
-   */
-  public function vaultPasswordFileInit() {
-    $vaultID = $this->getVaultId();
-    $this->taskExec('security add-generic-password -a ' . $vaultID . ' -s "' . $vaultID . ' Password" -w')->run();
+    /**
+     * Adds your vault password to the keychain.
+     *
+     * @command secrets:keychain:init
+     */
+    public function vaultPasswordFileInit() {
+        $vaultID = $this->getVaultId();
+        $this->taskExec('security add-generic-password -a ' . $vaultID . ' -s "' . $vaultID . ' Password" -w')->run();
 
-    $this->taskFilesystemStack()
-      ->touch($this->getConfigValue('repo.root') . '/secrets/.usekeychain')
-      ->run();
-  }
+        $this->taskFilesystemStack()
+            ->touch($this->getConfigValue('repo.root') . '/secrets/.usekeychain')
+            ->run();
+    }
 
-  /**
-   * Get the Password from keychain for decrypting the vault.
-   *
-   * @command secrets:vault:password
-   */
-  public function vaultPasswordFile() {
-    $vaultID = $this->getVaultId();
-    $this->taskExec(
-      "/usr/bin/security find-generic-password -w \
+    /**
+     * Get the Password from keychain for decrypting the vault.
+     *
+     * @command secrets:vault:password
+     */
+    public function vaultPasswordFile() {
+        $vaultID = $this->getVaultId();
+        $this->taskExec(
+            "/usr/bin/security find-generic-password -w \
         -a \"$vaultID\" -l \"$vaultID Password\" 2> /dev/null"
-    )->run();
-  }
-
-  /**
-   * Edit the vault file.
-   *
-   * @command secrets:edit
-   * @aliases seed
-   * @throws \Acquia\Blt\Robo\Exceptions\BltException
-   */
-  public function secretsEdit() {
-    $command = "ansible-vault edit secrets/secrets_vault" . $this->getVaultPasswordCommand();
-    $this->taskExec($command)->run();
-  }
-
-  /**
-   * Provide a diff on your vault for a particular environment.
-   *
-   * @command secrets:diff
-   * @aliases sedf
-   * @throws \Robo\Exception\TaskException
-   */
-  public function secretsDiff($drushAlias) {
-    $environments = $this->getEnvironments();
-
-    if (isset($environments[$drushAlias])) {
-      $ansibleCommand = $this->getPlaybookCommand(
-        $drushAlias,
-        $environments,
-        "-CD"
-      );
-
-      $this->taskExec($ansibleCommand)
-        ->run();
-    } else {
-      throw new BltException("Could not find Drush alias");
+        )->run();
     }
-  }
 
-  /**
-   * Deploy the secrets in a particular environment.
-   *
-   * @param string $drushAlias
-   *   The drush alias for the environment.
-   *
-   * @command secrets:deploy
-   * @aliases sedp
-   * @throws \Robo\Exception\TaskException
-   */
-  public function secretsDeploy($drushAlias) {
-    $environments = $this->getEnvironments();
-
-    if (isset($environments[$drushAlias])) {
-      $ansibleCommand = $this->getPlaybookCommand($drushAlias, $environments);
-      $this->taskExec($ansibleCommand)->run();
-    } else {
-      throw new BltException("Could not find Drush alias");
+    /**
+     * Edit the vault file.
+     *
+     * @command secrets:edit
+     * @aliases seed
+     * @throws \Acquia\Blt\Robo\Exceptions\BltException
+     */
+    public function secretsEdit() {
+        $command = "ansible-vault edit secrets/secrets_vault" . $this->getVaultPasswordCommand();
+        $this->taskExec($command)->run();
     }
-  }
 
-  /**
-   * Generate an ansible parameter for getting password from keychain.
-   *
-   * @return string
-   *   Return the vault-password-file parameter.
-   */
-  private function getVaultPasswordCommand() {
-    if (file_exists($this->getConfigValue('repo.root') . '/secrets/.usekeychain')) {
-      return ' --vault-password-file=' . $this->getConfigValue('repo.root') . $this->pluginRoot . '/ansible/vault_password_file';
-    } else {
-      return ' --ask-vault-pass';
+    /**
+     * Provide a diff on your vault for a particular environment.
+     *
+     * @command secrets:diff
+     * @aliases sedf
+     * @throws \Robo\Exception\TaskException
+     */
+    public function secretsDiff($drushAlias) {
+        $environments = $this->getEnvironments();
+
+        if (isset($environments[$drushAlias])) {
+            $ansibleCommand = $this->getPlaybookCommand(
+                $drushAlias,
+                $environments,
+                "-CD"
+            );
+
+            $this->taskExec($ansibleCommand)
+                ->run();
+        } else {
+            throw new BltException("Could not find Drush alias");
+        }
     }
-  }
 
-  /**
-   * Get a vault ID for naming keychain entry.
-   *
-   * @return string
-   *   The vault id used to define keychain entry name.
-   */
-  private function getVaultId() {
-    return $this->getConfigValue('project.machine_name') . '-ansible-vault';
-  }
+    /**
+     * Deploy the secrets in a particular environment.
+     *
+     * @param string $drushAlias
+     *   The drush alias for the environment.
+     *
+     * @command secrets:deploy
+     * @aliases sedp
+     * @throws \Robo\Exception\TaskException
+     */
+    public function secretsDeploy($drushAlias) {
+        $environments = $this->getEnvironments();
 
-  /**
-   * Retrieve the drush aliases defined.
-   *
-   * @return array
-   *   The environments defined in drush alias file.
-   *
-   * @throws \Robo\Exception\TaskException
-   */
-  private function getEnvironments() {
-    if (is_null($this->environments)) {
-      $this->environments = unserialize(
-        $this->taskDrush()
-          ->Drush("sa --format=php")
-          ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
-          ->run()
-          ->getMessage()
-      );
+        if (isset($environments[$drushAlias])) {
+            $ansibleCommand = $this->getPlaybookCommand($drushAlias, $environments);
+            $this->taskExec($ansibleCommand)->run();
+        } else {
+            throw new BltException("Could not find Drush alias");
+        }
     }
-    return $this->environments;
-  }
 
-  private function getSecretsRemoteLocation($drushAlias) {
-    $secrets_remote_location = $this->getConfigValue('secrets.settings-remote-location');
-    $environments = $this->getEnvironments();
-
-    if (!is_null($secrets_remote_location)) {
-      return $secrets_remote_location;
-    } else if (is_null($secrets_remote_location) && isset($environments[$drushAlias]['ac-site']) && isset($environments[$drushAlias]['ac-env'])) {
-      // We can calculate the expected location from drush alias.
-      return '/mnt/files/' . $environments[$drushAlias]['ac-site'] . '.' . $environments[$drushAlias]['ac-env'] . '/secrets.settings.php';
-    } else {
-      // Could not calculate location and was not set explicitly.
-      throw new BltException("Could not determine the secrets.settings.php remote location. Please define in BLT config 'secrets.settings-remote-location'");
+    /**
+     * Generate an ansible parameter for getting password from keychain.
+     *
+     * @return string
+     *   Return the vault-password-file parameter.
+     */
+    private function getVaultPasswordCommand() {
+        if (file_exists($this->getConfigValue('repo.root') . '/secrets/.usekeychain')) {
+            return ' --vault-password-file=' . $this->getConfigValue('repo.root') . $this->pluginRoot . '/ansible/vault_password_file';
+        } else {
+            return ' --ask-vault-pass';
+        }
     }
-  }
 
-  /**
-   * Get the ansible command for running the main playbook.
-   *
-   * @param string $drushAlias
-   *   The Drush alias.
-   * @param array $environments
-   *   Full list of environments from SecurityCommands::getEnvironments().
-   * @param string $arguments
-   *   Any extra arguments to ansible-playbook command.
-   *
-   * @return string
-   *   Full command for running the ansible playbook.
-   */
-  private function getPlaybookCommand($drushAlias, array $environments, $arguments = "") {
-    $defaultPlaybook = $this->getConfigValue('repo.root') . $this->pluginRoot . "/ansible/deploy-secrets.yml";
-    $playbook = $this->getConfigValue('secrets.playbook', $defaultPlaybook);
+    /**
+     * Get a vault ID for naming keychain entry.
+     *
+     * @return string
+     *   The vault id used to define keychain entry name.
+     */
+    private function getVaultId() {
+        return $this->getConfigValue('project.machine_name') . '-ansible-vault';
+    }
 
-    $secrets_vault_location = $this->getConfigValue('repo.root') . "/secrets/secrets_vault";
-    $secrets_template_location = $this->getConfigValue('repo.root') . "/secrets/secrets.settings.php.j2";
+    /**
+     * Retrieve the drush aliases defined.
+     *
+     * @return array
+     *   The environments defined in drush alias file.
+     *
+     * @throws \Robo\Exception\TaskException
+     */
+    private function getEnvironments() {
+        if (is_null($this->environments)) {
+            $this->environments = unserialize(
+                $this->taskDrush()
+                    ->Drush("sa --format=php")
+                    ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+                    ->run()
+                    ->getMessage()
+            );
+        }
+        return $this->environments;
+    }
 
-    $secrets_remote_location = $this->getSecretsRemoteLocation($drushAlias);
-    var_dump($secrets_remote_location);
-    if (!strstr($drushAlias, 'local')) {
-      $command = "ansible-playbook " . $arguments . " " . $playbook .
-        " -i " . $environments[$drushAlias]['host'] . ", -u " . $environments[$drushAlias]['user'] . " \
-        --extra-vars 'drush_alias=" . $drushAlias . " \
+    private function getSecretsRemoteLocation($drushAlias) {
+        $secrets_remote_location = $this->getConfigValue('secrets.settings-remote-location');
+        $environment = $this->getEnvironmentFacts($drushAlias);
+
+        if (!is_null($secrets_remote_location)) {
+            return $secrets_remote_location;
+        } else if (is_null($secrets_remote_location) && isset($environment['ac-site']) && isset($environment['ac-env'])) {
+            // We can calculate the expected location from drush alias.
+            return '/mnt/files/' . $environment['ac-site'] . '.' . $environment['ac-env'] . '/secrets.settings.php';
+        } else {
+            // Could not calculate location and was not set explicitly.
+            throw new BltException("Could not determine the secrets.settings.php remote location. Please define in BLT config 'secrets.settings-remote-location'");
+        }
+    }
+
+    /**
+     * Get the detailed variables for template substitution options.
+     *
+     * @param $drushAlias
+     * The Drush alias
+     *
+     * @return array
+     * Set of variables for template substitution.
+     */
+    private function getEnvironmentFacts($drushAlias) {
+        $environment = $this->getEnvironments()[$drushAlias];
+
+        $acSite = isset($environment['ac-site']) ? $environment['ac-site'] : str_replace("@", '', explode('.', $drushAlias)[0]);
+        $acEnv = isset($environment['ac-env']) ? $environment['ac-env'] : explode('.', $drushAlias)[1];
+
+        $facts = [
+            'alias' => $drushAlias,
+            'ac-site' => $acSite,
+            'ac-env' => $acEnv,
+            'stack' => preg_replace('/\D/', '', $acEnv),
+            'stack-env' => preg_replace('/\d/', '', $acEnv)
+        ];
+
+        // Set a value for local.
+        if ($facts['stack'] == "") { $facts['stack'] = "00";}
+
+        return $facts;
+    }
+
+    /**
+     * Get the ansible command for running the main playbook.
+     *
+     * @param string $drushAlias
+     *   The Drush alias.
+     * @param array $environments
+     *   Full list of environments from SecurityCommands::getEnvironments().
+     * @param string $arguments
+     *   Any extra arguments to ansible-playbook command.
+     *
+     * @return string
+     *   Full command for running the ansible playbook.
+     */
+    private function getPlaybookCommand($drushAlias, array $environments, $arguments = "") {
+        $defaultPlaybook = $this->getConfigValue('repo.root') . $this->pluginRoot . "/ansible/deploy-secrets.yml";
+        $playbook = $this->getConfigValue('secrets.playbook', $defaultPlaybook);
+
+        $secrets_vault_location = $this->getConfigValue('repo.root') . "/secrets/secrets_vault";
+        $secrets_template_location = $this->getConfigValue('repo.root') . "/secrets/secrets.settings.php.j2";
+
+        $environmentFacts = $this->getEnvironmentFacts($drushAlias);
+
+        $extraVars = " --extra-vars 'drush_alias=" . $drushAlias . " \
+        ac-site=" . $environmentFacts['ac-site'] . " \
+        ac-env=" . $environmentFacts['ac-env'] . " \
+        stack=" . $environmentFacts['stack'] . " \
+        stack-env=" . $environmentFacts['stack-env'] . " \
         secret_vault_location=" . $secrets_vault_location . " \
         secret_template_location=" . $secrets_template_location . " \
-        secret_location=" . $secrets_remote_location . "' "
-        . $this->getVaultPasswordCommand();
-    } else {
-      $secrets_local_location = $this->getConfigValue('repo.root') . '/docroot/sites/default/settings/secrets.settings.local';
-      $local_extra_vars = $this->getConfigValue('repo.root') . '/docroot/sites/default/settings/local.settings.php';
+        ";
 
-      $command = "ansible-playbook " . $arguments . " " . $playbook . " -i 127.0.0.1, \
-        --extra-vars 'drush_alias=" . $drushAlias . " \
-        secret_vault_location=" . $secrets_vault_location . " \
-        secret_template_location=" . $secrets_template_location . " \
-        secret_location=" . $secrets_local_location . " \
-        localsettings_location=" . $local_extra_vars . " \
-        ansible_connection=local' "
-        . $this->getVaultPasswordCommand();
+        if (!strstr($drushAlias, 'local')) {
+            $host = " -i " . $environments[$drushAlias]['host'] . ", -u " . $environments[$drushAlias]['user'];
+            $extraVars .= "secret_location=" . $this->getSecretsRemoteLocation($drushAlias) . "' ";
+        } else {
+            $host = " -i 127.0.0.1";
+            $extraVars .= "secret_location=" . $this->getConfigValue('repo.root') . '/docroot/sites/default/settings/secrets.settings.local' . " \
+        localsettings_location=" . $this->getConfigValue('repo.root') . '/docroot/sites/default/settings/local.settings.php' . " \
+        ansible_connection=local' ";
+        }
+
+        $command = "ansible-playbook " . $arguments . " " . $playbook . $host . $extraVars . $this->getVaultPasswordCommand();
+
+        return $command;
     }
-
-    return $command;
-  }
 }


### PR DESCRIPTION
Exposes more variable names to the php template to allow for more fine grained customisation especially in multistack architectures

alias
ac-site
ac-env
stack
stack-env

e.g.

drush_alias=@somesite3.03live
ac-site=somesite3
ac-env=03live
stack=03
stack-env=live